### PR TITLE
chore: add Zone.Identifier to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ checklink/cookies.txt
 
 # Quarto
 .quarto
+
+# Windows Alternative Data Streams (Zone.Identifier)
+*:Zone.Identifier
+*.Zone.Identifier


### PR DESCRIPTION
This hygiene PR adds Windows NTFS Alternative Data Streams (`*:Zone.Identifier`) to `.gitignore`. 
This prevents cross-platform development environments (specifically Git for Windows) from throwing `invalid path` errors during checkout/reset due to untracked metadata.