### PR TITLE
fix(metadata): correct Shapely bounds unpacking order in BboxCB

### DIFF
--- a/marisco/metadata.py
+++ b/marisco/metadata.py
@@ -57,7 +57,7 @@ class BboxCB(Callback):
     "Compute dataset geographical bounding box"
     def __call__(self, obj):
         bbox = get_bbox(pd.concat(obj.dfs))     
-        lon_min, lon_max, lat_min, lat_max = [str(bound) for bound in bbox.bounds]
+        lon_min, lat_min, lon_max, lat_max = [str(bound) for bound in bbox.bounds]
         obj.attrs.update({
             'geospatial_lat_min': lat_min, 
             'geospatial_lat_max': lat_max,

--- a/nbs/api/metadata.ipynb
+++ b/nbs/api/metadata.ipynb
@@ -132,20 +132,7 @@
    "id": "e29022dc",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "#| export\n",
-    "class BboxCB(Callback):\n",
-    "    \"Compute dataset geographical bounding box\"\n",
-    "    def __call__(self, obj):\n",
-    "        bbox = get_bbox(pd.concat(obj.dfs))     \n",
-    "        lon_min, lon_max, lat_min, lat_max = [str(bound) for bound in bbox.bounds]\n",
-    "        obj.attrs.update({\n",
-    "            'geospatial_lat_min': lat_min, \n",
-    "            'geospatial_lat_max': lat_max,\n",
-    "            'geospatial_lon_min': lon_min,\n",
-    "            'geospatial_lon_max': lon_max,\n",
-    "            'geospatial_bounds': bbox.wkt})"
-   ]
+   "source": "#| export\nclass BboxCB(Callback):\n    \"Compute dataset geographical bounding box\"\n    def __call__(self, obj):\n        bbox = get_bbox(pd.concat(obj.dfs))     \n        lon_min, lat_min, lon_max, lat_max = [str(bound) for bound in bbox.bounds]\n        obj.attrs.update({\n            'geospatial_lat_min': lat_min, \n            'geospatial_lat_max': lat_max,\n            'geospatial_lon_min': lon_min,\n            'geospatial_lon_max': lon_max,\n            'geospatial_bounds': bbox.wkt})"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
This PR fixes a critical coordinate-swapping bug in the shared `BboxCB` class. 
Previously, `geospatial_lat_min` and `geospatial_lon_max` were mixed up in the global attributes across all generated NetCDF files.

## Root Cause Analysis
Shapely's `geometry.bounds` property always returns a tuple in the order of `(minx, miny, maxx, maxy)`. 
Since `marisco` maps `LON` to X and `LAT` to Y, the correct unpacking order must be:
`(min_lon, min_lat, max_lon, max_lat)`

However, the previous implementation in `BboxCB` incorrectly unpacked it as:
`lon_min, lon_max, lat_min, lat_max`

This mismatched sequence led to `miny` (min latitude) being assigned to `lon_max`, and `maxx` (max longitude) being assigned to `lat_min`.

## Verification & Proof
I created a standalone verification script with mock datasets to capture the exact behavior before and after the fix. 

### Before Fix (Bugged Output)
- **Input range:** LAT: 78.1 ~ 78.9 | LON: -15.0 ~ 5.0
- **Generated attributes:**
  - `geospatial_lat_min`: `5.0` (This is actually the max longitude!)
  - `geospatial_lon_max`: `78.1` (This is actually the min latitude!)

### After Fix (Correct Output)
- `geospatial_lat_min`: `78.1` (Correct)
- `geospatial_lat_max`: `78.9` (Correct)
- `geospatial_lon_min`: `-15.0` (Correct)
- `geospatial_lon_max`: `5.0` (Correct)

*Note: You can also see evidence of this bug in the existing `Usage` cell of the API notebook, where `geospatial_lat_min` was recorded as `'179.9986'` (clearly a longitude value).*

## Changes Made
- Modified `nbs/api/metadata.ipynb` (Cell `e29022dc`) to fix the unpacking sequence.
- Re-exported via `nbdev` to update `marisco/metadata.py`.

No other logic or schemas were broken. All validation pipelines passed smoothly.